### PR TITLE
Support new options

### DIFF
--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -580,6 +580,7 @@ NIF(erlzmq_nif_getsockopt)
     case ZMQ_GSSAPI_PRINCIPAL:
     case ZMQ_GSSAPI_SERVICE_PRINCIPAL:
     case ZMQ_LAST_ENDPOINT:
+    case ZMQ_BINDTODEVICE:
     
     #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
     // string
@@ -591,7 +592,7 @@ NIF(erlzmq_nif_getsockopt)
     case ZMQ_ZAP_DOMAIN:
     case ZMQ_PLAIN_PASSWORD:
     case ZMQ_PLAIN_USERNAME:
-    case ZMQ_BINDTODEVICE:
+    
     // binary or Z85 string
     case ZMQ_CURVE_PUBLICKEY:
     case ZMQ_CURVE_SECRETKEY:

--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -31,6 +31,18 @@
 
 #define ERLZMQ_MAX_CONCURRENT_REQUESTS 16384
 
+#ifndef ZMQ_ROUTING_ID
+#define ZMQ_ROUTING_ID ZMQ_IDENTITY
+#endif
+
+#ifndef ZMQ_CONNECT_ROUTING_ID
+#define ZMQ_CONNECT_ROUTING_ID ZMQ_CONNECT_RID
+#endif
+
+#ifndef ZMQ_IMMEDIATE
+#define ZMQ_IMMEDIATE ZMQ_DELAY_ATTACH_ON_CONNECT
+#endif
+
 static ErlNifResourceType* erlzmq_nif_resource_context;
 static ErlNifResourceType* erlzmq_nif_resource_socket;
 

--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -592,7 +592,11 @@ NIF(erlzmq_nif_getsockopt)
     case ZMQ_GSSAPI_PRINCIPAL:
     case ZMQ_GSSAPI_SERVICE_PRINCIPAL:
     case ZMQ_LAST_ENDPOINT:
+    
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 3
+    // string
     case ZMQ_BINDTODEVICE:
+    #endif
     
     #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
     // string

--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -344,6 +344,12 @@ NIF(erlzmq_nif_setsockopt)
   switch (option_name) {
     // uint64_t
     case ZMQ_AFFINITY:
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
+    case ZMQ_VMCI_BUFFER_SIZE:
+    case ZMQ_VMCI_BUFFER_MIN_SIZE:
+    case ZMQ_VMCI_BUFFER_MAX_SIZE:
+    #endif
       if (! enif_get_uint64(env, argv[2], &value_uint64)) {
         return enif_make_badarg(env);
       }
@@ -359,10 +365,43 @@ NIF(erlzmq_nif_setsockopt)
       option_value = &value_int64;
       option_len = sizeof(int64_t);
       break;
+
     // binary
-    case ZMQ_IDENTITY:
+    case ZMQ_CONNECT_ROUTING_ID:
+    case ZMQ_ROUTING_ID:
     case ZMQ_SUBSCRIBE:
     case ZMQ_UNSUBSCRIBE:
+
+    // deprecated
+    case ZMQ_TCP_ACCEPT_FILTER:
+    
+    // character string
+    case ZMQ_GSSAPI_PRINCIPAL:
+    case ZMQ_GSSAPI_SERVICE_PRINCIPAL:
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 3
+    // string
+    case ZMQ_BINDTODEVICE:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
+    // string
+    case ZMQ_SOCKS_PROXY:
+    // binary
+    case ZMQ_XPUB_WELCOME_MSG:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 0
+    // string
+    case ZMQ_ZAP_DOMAIN:
+    case ZMQ_PLAIN_PASSWORD:
+    case ZMQ_PLAIN_USERNAME:
+    
+    // binary or Z85 string
+    case ZMQ_CURVE_PUBLICKEY:
+    case ZMQ_CURVE_SECRETKEY:
+    case ZMQ_CURVE_SERVERKEY:
+    #endif
       if (! enif_inspect_iolist_as_binary(env, argv[2], &value_binary)) {
         return enif_make_badarg(env);
       }
@@ -370,20 +409,70 @@ NIF(erlzmq_nif_setsockopt)
       option_len = value_binary.size;
       break;
     // int
-    case ZMQ_SNDHWM:
-    case ZMQ_RCVHWM:
-    case ZMQ_RATE:
-    case ZMQ_RECOVERY_IVL:
-    case ZMQ_RCVBUF:
-    case ZMQ_SNDBUF:
+    case ZMQ_BACKLOG:
+    case ZMQ_CURVE_SERVER:
+    case ZMQ_GSSAPI_PLAINTEXT:
+    case ZMQ_GSSAPI_SERVER:
+    case ZMQ_IMMEDIATE:
+    case ZMQ_IPV6:
     case ZMQ_LINGER:
+    case ZMQ_MULTICAST_HOPS:
+    case ZMQ_RATE:
+    case ZMQ_RCVBUF:
+    case ZMQ_RCVHWM:
+    case ZMQ_RCVTIMEO:
     case ZMQ_RECONNECT_IVL:
     case ZMQ_RECONNECT_IVL_MAX:
-    case ZMQ_BACKLOG:
-    case ZMQ_MULTICAST_HOPS:
-    case ZMQ_RCVTIMEO:
+    case ZMQ_RECOVERY_IVL:
+    case ZMQ_ROUTER_MANDATORY:
+    case ZMQ_ROUTER_RAW:
+    case ZMQ_SNDBUF:
+    case ZMQ_SNDHWM:
     case ZMQ_SNDTIMEO:
+    case ZMQ_TCP_KEEPALIVE:
+    case ZMQ_TCP_KEEPALIVE_CNT:
+    case ZMQ_TCP_KEEPALIVE_IDLE:
+    case ZMQ_TCP_KEEPALIVE_INTVL:
+    case ZMQ_XPUB_VERBOSE:
+    
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 3
+    case ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE:
+    case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
+    case ZMQ_USE_FD:
+    case ZMQ_VMCI_CONNECT_TIMEOUT:
+    case ZMQ_MULTICAST_MAXTPDU:
+    case ZMQ_TCP_MAXRT:
+    case ZMQ_CONNECT_TIMEOUT:
+    case ZMQ_XPUB_VERBOSER:
+    case ZMQ_HEARTBEAT_TIMEOUT:
+    case ZMQ_HEARTBEAT_TTL:
+    case ZMQ_HEARTBEAT_IVL:
+    case ZMQ_INVERT_MATCHING:
+    case ZMQ_STREAM_NOTIFY:
+    case ZMQ_XPUB_MANUAL:
+    case ZMQ_HANDSHAKE_IVL:
+    case ZMQ_XPUB_NODROP:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 1
+    case ZMQ_TOS:
+    case ZMQ_ROUTER_HANDOVER:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 0
+    case ZMQ_CONFLATE:
+    case ZMQ_REQ_RELAXED:
+    case ZMQ_REQ_CORRELATE:
+    case ZMQ_PROBE_ROUTER:
+    case ZMQ_PLAIN_SERVER:
+    #endif
+
+    // deprecated
     case ZMQ_IPV4ONLY:
+
       if (! enif_get_int(env, argv[2], &value_int)) {
         return enif_make_badarg(env);
       }
@@ -459,6 +548,12 @@ NIF(erlzmq_nif_getsockopt)
                               enif_make_int64(env, value_int64));
     // uint64_t
     case ZMQ_AFFINITY:
+    
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
+    case ZMQ_VMCI_BUFFER_SIZE:
+    case ZMQ_VMCI_BUFFER_MIN_SIZE:
+    case ZMQ_VMCI_BUFFER_MAX_SIZE:
+    #endif
       option_len = sizeof(value_uint64);
       if (! socket->mutex) {
         return return_zmq_errno(env, ETERM);
@@ -479,7 +574,29 @@ NIF(erlzmq_nif_getsockopt)
       return enif_make_tuple2(env, enif_make_atom(env, "ok"),
                               enif_make_uint64(env, value_uint64));
     // binary
-    case ZMQ_IDENTITY:
+    case ZMQ_ROUTING_ID:
+
+    // string
+    case ZMQ_GSSAPI_PRINCIPAL:
+    case ZMQ_GSSAPI_SERVICE_PRINCIPAL:
+    case ZMQ_LAST_ENDPOINT:
+    
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
+    // string
+    case ZMQ_SOCKS_PROXY:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 0
+    // string
+    case ZMQ_ZAP_DOMAIN:
+    case ZMQ_PLAIN_PASSWORD:
+    case ZMQ_PLAIN_USERNAME:
+    case ZMQ_BINDTODEVICE:
+    // binary or Z85 string
+    case ZMQ_CURVE_PUBLICKEY:
+    case ZMQ_CURVE_SECRETKEY:
+    case ZMQ_CURVE_SERVERKEY:
+    #endif
       option_len = sizeof(option_value);
       if (! socket->mutex) {
         return return_zmq_errno(env, ETERM);
@@ -502,24 +619,62 @@ NIF(erlzmq_nif_getsockopt)
       return enif_make_tuple2(env, enif_make_atom(env, "ok"),
                               enif_make_binary(env, &value_binary));
     // int
-    case ZMQ_TYPE:
-    case ZMQ_RCVMORE:
-    case ZMQ_SNDHWM:
-    case ZMQ_RCVHWM:
-    case ZMQ_RATE:
-    case ZMQ_RECOVERY_IVL:
-    case ZMQ_SNDBUF:
-    case ZMQ_RCVBUF:
+    case ZMQ_BACKLOG:
+    case ZMQ_CURVE_SERVER:
+    case ZMQ_GSSAPI_PLAINTEXT:
+    case ZMQ_GSSAPI_SERVER:
+    case ZMQ_IMMEDIATE:
+    case ZMQ_IPV6:
     case ZMQ_LINGER:
+    case ZMQ_MULTICAST_HOPS:
+    case ZMQ_RATE:
+    case ZMQ_RCVBUF:
+    case ZMQ_RCVHWM:
+    case ZMQ_RCVTIMEO:
     case ZMQ_RECONNECT_IVL:
     case ZMQ_RECONNECT_IVL_MAX:
-    case ZMQ_BACKLOG:
-    case ZMQ_MULTICAST_HOPS:
-    case ZMQ_RCVTIMEO:
+    case ZMQ_RECOVERY_IVL:
+    case ZMQ_SNDBUF:
+    case ZMQ_SNDHWM:
     case ZMQ_SNDTIMEO:
-    case ZMQ_IPV4ONLY:
+    case ZMQ_TCP_KEEPALIVE:
+    case ZMQ_TCP_KEEPALIVE_CNT:
+    case ZMQ_TCP_KEEPALIVE_IDLE:
+    case ZMQ_TCP_KEEPALIVE_INTVL:
+    case ZMQ_RCVMORE:
     case ZMQ_EVENTS:
-    case ZMQ_FD:   // FIXME: ZMQ_FD returns SOCKET on Windows
+    case ZMQ_TYPE:
+    case ZMQ_MECHANISM:
+    
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 3
+    case ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE:
+    case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 2
+    case ZMQ_USE_FD:
+    case ZMQ_VMCI_CONNECT_TIMEOUT:
+    case ZMQ_MULTICAST_MAXTPDU:
+    case ZMQ_THREAD_SAFE:
+    case ZMQ_TCP_MAXRT:
+    case ZMQ_CONNECT_TIMEOUT:
+    case ZMQ_INVERT_MATCHING:
+    case ZMQ_HANDSHAKE_IVL:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 1
+    case ZMQ_TOS:
+    #endif
+
+    #if ZMQ_VERSION_MAJOR > 4 || ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR >= 0
+    case ZMQ_PLAIN_SERVER:
+    #endif
+    // FIXME SOCKET on Windows, int on POSIX
+    case ZMQ_FD:
+
+    // deprecated
+    case ZMQ_IPV4ONLY:
+
       option_len = sizeof(value_int);
       if (! socket->mutex) {
         return return_zmq_errno(env, ETERM);
@@ -1450,6 +1605,9 @@ static ERL_NIF_TERM return_zmq_errno(ErlNifEnv* env, int const value)
     case ETIMEDOUT:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "etimedout"));
+    case EHOSTUNREACH:
+      return enif_make_tuple2(env, enif_make_atom(env, "error"),
+                              enif_make_atom(env, "ehostunreach"));
     case ECONNREFUSED:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "econnrefused"));
@@ -1459,40 +1617,16 @@ static ERL_NIF_TERM return_zmq_errno(ErlNifEnv* env, int const value)
     case ENAMETOOLONG:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "enametoolong"));
-    case (ZMQ_HAUSNUMERO +  1):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "enotsup"));
-    case (ZMQ_HAUSNUMERO +  2):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "eprotonosupport"));
-    case (ZMQ_HAUSNUMERO +  3):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "enobufs"));
-    case (ZMQ_HAUSNUMERO +  4):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "enetdown"));
-    case (ZMQ_HAUSNUMERO +  5):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "eaddrinuse"));
-    case (ZMQ_HAUSNUMERO +  6):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "eaddrnotavail"));
-    case (ZMQ_HAUSNUMERO +  7):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "econnrefused"));
-    case (ZMQ_HAUSNUMERO +  8):
-      return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                              enif_make_atom(env, "einprogress"));
-    case (ZMQ_HAUSNUMERO + 51):
+    case EFSM:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "efsm"));
-    case (ZMQ_HAUSNUMERO + 52):
+    case ENOCOMPATPROTO:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "enocompatproto"));
-    case (ZMQ_HAUSNUMERO + 53):
+    case ETERM:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "eterm"));
-    case (ZMQ_HAUSNUMERO + 54):
+    case EMTHREAD:
       return enif_make_tuple2(env, enif_make_atom(env, "error"),
                               enif_make_atom(env, "emthread"));
     default:

--- a/include/erlzmq.hrl
+++ b/include/erlzmq.hrl
@@ -5,42 +5,109 @@
 -define('ZMQ_REP',          4).
 -define('ZMQ_DEALER',       5).
 -define('ZMQ_ROUTER',       6).
--define('ZMQ_XREQ',         ?'ZMQ_DEALER').
--define('ZMQ_XREP',         ?'ZMQ_ROUTER').
 -define('ZMQ_PULL',         7).
 -define('ZMQ_PUSH',         8).
 -define('ZMQ_XPUB',         9).
 -define('ZMQ_XSUB',        10).
+-define('ZMQ_STREAM',      11).
+% deprecated
+-define('ZMQ_XREQ',         ?'ZMQ_DEALER').
+-define('ZMQ_XREP',         ?'ZMQ_ROUTER').
 
 % ZMQ socket options.
--define('ZMQ_AFFINITY',           4).
--define('ZMQ_IDENTITY',           5).
--define('ZMQ_SUBSCRIBE',          6).
--define('ZMQ_UNSUBSCRIBE',        7).
--define('ZMQ_RATE',               8).
--define('ZMQ_RECOVERY_IVL',       9).
--define('ZMQ_SNDBUF',            11).
--define('ZMQ_RCVBUF',            12).
--define('ZMQ_RCVMORE',           13).
--define('ZMQ_FD',                14).
--define('ZMQ_EVENTS',            15).
--define('ZMQ_TYPE',              16).
--define('ZMQ_LINGER',            17).
--define('ZMQ_RECONNECT_IVL',     18).
--define('ZMQ_BACKLOG',           19).
--define('ZMQ_RECOVERY_IVL_MSEC', 20).
+-define('ZMQ_AFFINITY', 4).
+-define('ZMQ_ROUTING_ID', 5).
+-define('ZMQ_SUBSCRIBE', 6).
+-define('ZMQ_UNSUBSCRIBE', 7).
+-define('ZMQ_RATE', 8).
+-define('ZMQ_RECOVERY_IVL', 9).
+-define('ZMQ_SNDBUF', 11).
+-define('ZMQ_RCVBUF', 12).
+-define('ZMQ_RCVMORE', 13).
+-define('ZMQ_FD', 14).
+-define('ZMQ_EVENTS', 15).
+-define('ZMQ_TYPE', 16).
+-define('ZMQ_LINGER', 17).
+-define('ZMQ_RECONNECT_IVL', 18).
+-define('ZMQ_BACKLOG', 19).
 -define('ZMQ_RECONNECT_IVL_MAX', 21).
--define('ZMQ_MAXMSGSIZE',        22).
--define('ZMQ_SNDHWM',            23).
--define('ZMQ_RCVHWM',            24).
--define('ZMQ_MULTICAST_HOPS',    25).
--define('ZMQ_RCVTIMEO',          27).
--define('ZMQ_SNDTIMEO',          28).
--define('ZMQ_IPV4ONLY',          31).
--define('ZMQ_LAST_ENDPOINT',     32).
+-define('ZMQ_MAXMSGSIZE', 22).
+-define('ZMQ_SNDHWM', 23).
+-define('ZMQ_RCVHWM', 24).
+-define('ZMQ_MULTICAST_HOPS', 25).
+-define('ZMQ_RCVTIMEO', 27).
+-define('ZMQ_SNDTIMEO', 28).
+-define('ZMQ_LAST_ENDPOINT', 32).
+-define('ZMQ_ROUTER_MANDATORY', 33).
+-define('ZMQ_TCP_KEEPALIVE', 34).
+-define('ZMQ_TCP_KEEPALIVE_CNT', 35).
+-define('ZMQ_TCP_KEEPALIVE_IDLE', 36).
+-define('ZMQ_TCP_KEEPALIVE_INTVL', 37).
+-define('ZMQ_IMMEDIATE', 39).
+-define('ZMQ_XPUB_VERBOSE', 40).
+-define('ZMQ_ROUTER_RAW', 41).
+-define('ZMQ_IPV6', 42).
+-define('ZMQ_MECHANISM', 43).
+-define('ZMQ_PLAIN_SERVER', 44).
+-define('ZMQ_PLAIN_USERNAME', 45).
+-define('ZMQ_PLAIN_PASSWORD', 46).
+-define('ZMQ_CURVE_SERVER', 47).
+-define('ZMQ_CURVE_PUBLICKEY', 48).
+-define('ZMQ_CURVE_SECRETKEY', 49).
+-define('ZMQ_CURVE_SERVERKEY', 50).
+-define('ZMQ_PROBE_ROUTER', 51).
+-define('ZMQ_REQ_CORRELATE', 52).
+-define('ZMQ_REQ_RELAXED', 53).
+-define('ZMQ_CONFLATE', 54).
+-define('ZMQ_ZAP_DOMAIN', 55).
+-define('ZMQ_ROUTER_HANDOVER', 56).
+-define('ZMQ_TOS', 57).
+-define('ZMQ_CONNECT_ROUTING_ID', 61).
+-define('ZMQ_GSSAPI_SERVER', 62).
+-define('ZMQ_GSSAPI_PRINCIPAL', 63).
+-define('ZMQ_GSSAPI_SERVICE_PRINCIPAL', 64).
+-define('ZMQ_GSSAPI_PLAINTEXT', 65).
+-define('ZMQ_HANDSHAKE_IVL', 66).
+-define('ZMQ_SOCKS_PROXY', 68).
+-define('ZMQ_XPUB_NODROP', 69).
+% context option
+% -define('ZMQ_BLOCKY', 70).
+-define('ZMQ_XPUB_MANUAL', 71).
+-define('ZMQ_XPUB_WELCOME_MSG', 72).
+-define('ZMQ_STREAM_NOTIFY', 73).
+-define('ZMQ_INVERT_MATCHING', 74).
+-define('ZMQ_HEARTBEAT_IVL', 75).
+-define('ZMQ_HEARTBEAT_TTL', 76).
+-define('ZMQ_HEARTBEAT_TIMEOUT', 77).
+-define('ZMQ_XPUB_VERBOSER', 78).
+-define('ZMQ_CONNECT_TIMEOUT', 79).
+-define('ZMQ_TCP_MAXRT', 80).
+-define('ZMQ_THREAD_SAFE', 81).
+-define('ZMQ_MULTICAST_MAXTPDU', 84).
+-define('ZMQ_VMCI_BUFFER_SIZE', 85).
+-define('ZMQ_VMCI_BUFFER_MIN_SIZE', 86).
+-define('ZMQ_VMCI_BUFFER_MAX_SIZE', 87).
+-define('ZMQ_VMCI_CONNECT_TIMEOUT', 88).
+-define('ZMQ_USE_FD', 89).
+-define('ZMQ_GSSAPI_PRINCIPAL_NAMETYPE', 90).
+-define('ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE', 91).
+-define('ZMQ_BINDTODEVICE', 92).
+% deprecated
+-define('ZMQ_TCP_ACCEPT_FILTER', 38).
+-define('ZMQ_IPV4ONLY', 31).
+-define('ZMQ_IDENTITY', ?'ZMQ_ROUTING_ID').
+-define('ZMQ_CONNECT_RID', ?'ZMQ_CONNECT_ROUTING_ID').
+-define('ZMQ_DELAY_ATTACH_ON_CONNECT', ?'ZMQ_IMMEDIATE').
+-define('ZMQ_NOBLOCK', ?'ZMQ_DONTWAIT').
+-define('ZMQ_FAIL_UNROUTABLE', ?'ZMQ_ROUTER_MANDATORY').
+-define('ZMQ_ROUTER_BEHAVIOR', ?'ZMQ_ROUTER_MANDATORY').
+
 
 %  Message options
 -define('ZMQ_MORE',  1).
+-define('ZMQ_SHARED',  3).
+% deprecated
+-define('ZMQ_SRCFD',  2).
 
 % ZMQ send/recv flags
 -define('ZMQ_DONTWAIT',    1).
@@ -52,7 +119,7 @@
 %% <i>For more information see
 %% <a href="http://api.zeromq.org/master:zmq_socket">zmq_socket</a></i>
 -type erlzmq_socket_type() :: pair | pub | sub | req | rep | dealer | router | xreq | xrep |
-                            pull | push | xpub | xsub.
+                            pull | push | xpub | xsub | stream.
 
 %% The endpoint argument is a string consisting of two parts:
 %% <b>transport://address</b><br />
@@ -75,13 +142,11 @@
                  esocktnosupport | enotsup | epfnosupport | eafnosupport |
                  eaddrinuse | eaddrnotavail | enetdown | enetunreach |
                  enetreset | econnaborted | econnreset | enobufs | eisconn |
-                 enotconn | eshutdown | etoomanyrefs |
-                 etimedout | econnrefused | eloop | enametoolong.
+                 enotconn | eshutdown | etoomanyrefs | ehostunreach |
+                 etimedout | econnrefused | eloop | enametoolong | eaddnotavail.
 
 %% Possible error types.
--type erlzmq_error_type() :: enotsup | eprotonosupport | enobufs | enetdown |
-                           eaddrinuse | eaddnotavail | econnrefused |
-                           einprogress | efsm | enocompatproto | eterm |
+-type erlzmq_error_type() :: efsm | enocompatproto | eterm |
                            emthread | errno() | {unknown, integer()}.
 
 %% Error tuples returned by most API functions.
@@ -113,13 +178,91 @@
 %% <i>For more information see
 %% <a href="http://api.zeromq.org/master:zmq_setsockopt">zmq_setsockopt</a>
 %% and <a href="http://api.zeromq.org/master:zmq_getsockopt">zmq_getsockopt</a></i>
--type erlzmq_sockopt() :: affinity | identity | subscribe |
-                          unsubscribe | rate | recovery_ivl | sndbuf |
-                          rcvbuf | rcvmore | fd | events | linger |
-                          reconnect_ivl | backlog |reconnect_ivl_max
-                          | maxmsgsize | sndhwm | rcvhwm |
-                          multicast_hops | rcvtimeo | sndtimeo |
-                          ipv4only.
+-type erlzmq_sockopt() :: 
+    affinity |
+    routing_id |
+    subscribe |
+    unsubscribe |
+    rate |
+    recovery_ivl |
+    sndbuf |
+    rcvbuf |
+    rcvmore |
+    fd |
+    events |
+    type |
+    linger |
+    reconnect_ivl |
+    backlog |
+    reconnect_ivl_max |
+    maxmsgsize |
+    sndhwm |
+    rcvhwm |
+    multicast_hops |
+    rcvtimeo |
+    sndtimeo |
+    last_endpoint |
+    router_mandatory |
+    tcp_keepalive |
+    tcp_keepalive_cnt |
+    tcp_keepalive_idle |
+    tcp_keepalive_intvl |
+    immediate |
+    xpub_verbose |
+    router_raw |
+    ipv6 |
+    mechanism |
+    plain_server |
+    plain_username |
+    plain_password |
+    curve_server |
+    curve_publickey |
+    curve_secretkey |
+    curve_serverkey |
+    probe_router |
+    req_correlate |
+    req_relaxed |
+    conflate |
+    zap_domain |
+    router_handover |
+    tos |
+    connect_routing_id |
+    gssapi_server |
+    gssapi_principal |
+    gssapi_service_principal |
+    gssapi_plaintext |
+    handshake_ivl |
+    socks_proxy |
+    xpub_nodrop |
+    xpub_manual |
+    xpub_welcome_msg |
+    stream_notify |
+    invert_matching |
+    heartbeat_ivl |
+    heartbeat_ttl |
+    heartbeat_timeout |
+    xpub_verboser |
+    connect_timeout |
+    tcp_maxrt |
+    thread_safe |
+    multicast_maxtpdu |
+    vmci_buffer_size |
+    vmci_buffer_min_size |
+    vmci_buffer_max_size |
+    vmci_connect_timeout |
+    use_fd |
+    gssapi_principal_nametype |
+    gssapi_service_principal_nametype |
+    bindtodevice |
+    % deprecated
+    ipv4only |
+    tcp_accept_filter |
+    connect_rid |
+    delay_attach_on_connect |
+    noblock |
+    fail_unroutable |
+    router_behavior |
+    identity.
 
 
 %% Possible option values for {@link erlzmq:setsockopt/3. setsockopt/3}.

--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -403,10 +403,12 @@ socket_type(rep) ->
     ?'ZMQ_REP';
 socket_type(dealer) ->
     ?'ZMQ_DEALER';
+% deprecated
 socket_type(xreq) ->
     ?'ZMQ_XREQ';
 socket_type(router) ->
     ?'ZMQ_ROUTER';
+% deprecated
 socket_type(xrep) ->
     ?'ZMQ_XREP';
 socket_type(pull) ->
@@ -416,7 +418,9 @@ socket_type(push) ->
 socket_type(xpub) ->
     ?'ZMQ_XPUB';
 socket_type(xsub) ->
-    ?'ZMQ_XSUB'.
+    ?'ZMQ_XSUB';
+socket_type(stream) ->
+    ?'ZMQ_STREAM'.
 
 -spec sendrecv_flags(Flags :: erlzmq_send_recv_flags()) ->
     integer().
@@ -431,47 +435,89 @@ sendrecv_flags([sndmore|Rest]) ->
 -spec option_name(Name :: erlzmq_sockopt()) ->
     integer().
 
-option_name(affinity) ->
-    ?'ZMQ_AFFINITY';
-option_name(identity) ->
-    ?'ZMQ_IDENTITY';
-option_name(subscribe) ->
-    ?'ZMQ_SUBSCRIBE';
-option_name(unsubscribe) ->
-    ?'ZMQ_UNSUBSCRIBE';
-option_name(rate) ->
-    ?'ZMQ_RATE';
-option_name(recovery_ivl) ->
-    ?'ZMQ_RECOVERY_IVL';
-option_name(sndbuf) ->
-    ?'ZMQ_SNDBUF';
-option_name(rcvbuf) ->
-    ?'ZMQ_RCVBUF';
-option_name(rcvmore) ->
-    ?'ZMQ_RCVMORE';
-option_name(fd) ->
-    ?'ZMQ_FD';
-option_name(events) ->
-    ?'ZMQ_EVENTS';
-option_name(linger) ->
-    ?'ZMQ_LINGER';
-option_name(reconnect_ivl) ->
-    ?'ZMQ_RECONNECT_IVL';
-option_name(backlog) ->
-    ?'ZMQ_BACKLOG';
-option_name(reconnect_ivl_max) ->
-    ?'ZMQ_RECONNECT_IVL_MAX';
-option_name(maxmsgsize) ->
-    ?'ZMQ_MAXMSGSIZE';
-option_name(sndhwm) ->
-    ?'ZMQ_SNDHWM';
-option_name(rcvhwm) ->
-    ?'ZMQ_RCVHWM';
-option_name(multicast_hops) ->
-    ?'ZMQ_MULTICAST_HOPS';
-option_name(rcvtimeo) ->
-    ?'ZMQ_RCVTIMEO';
-option_name(sndtimeo) ->
-    ?'ZMQ_SNDTIMEO';
-option_name(ipv4only) ->
-    ?'ZMQ_IPV4ONLY'.
+option_name(affinity) -> ?'ZMQ_AFFINITY';
+option_name(routing_id) -> ?'ZMQ_ROUTING_ID';
+option_name(subscribe) -> ?'ZMQ_SUBSCRIBE';
+option_name(unsubscribe) -> ?'ZMQ_UNSUBSCRIBE';
+option_name(rate) -> ?'ZMQ_RATE';
+option_name(recovery_ivl) -> ?'ZMQ_RECOVERY_IVL';
+option_name(sndbuf) -> ?'ZMQ_SNDBUF';
+option_name(rcvbuf) -> ?'ZMQ_RCVBUF';
+option_name(rcvmore) -> ?'ZMQ_RCVMORE';
+option_name(fd) -> ?'ZMQ_FD';
+option_name(events) -> ?'ZMQ_EVENTS';
+option_name(type) -> ?'ZMQ_TYPE';
+option_name(linger) -> ?'ZMQ_LINGER';
+option_name(reconnect_ivl) -> ?'ZMQ_RECONNECT_IVL';
+option_name(backlog) -> ?'ZMQ_BACKLOG';
+option_name(reconnect_ivl_max) -> ?'ZMQ_RECONNECT_IVL_MAX';
+option_name(maxmsgsize) -> ?'ZMQ_MAXMSGSIZE';
+option_name(sndhwm) -> ?'ZMQ_SNDHWM';
+option_name(rcvhwm) -> ?'ZMQ_RCVHWM';
+option_name(multicast_hops) -> ?'ZMQ_MULTICAST_HOPS';
+option_name(rcvtimeo) -> ?'ZMQ_RCVTIMEO';
+option_name(sndtimeo) -> ?'ZMQ_SNDTIMEO';
+option_name(last_endpoint) -> ?'ZMQ_LAST_ENDPOINT';
+option_name(router_mandatory) -> ?'ZMQ_ROUTER_MANDATORY';
+option_name(tcp_keepalive) -> ?'ZMQ_TCP_KEEPALIVE';
+option_name(tcp_keepalive_cnt) -> ?'ZMQ_TCP_KEEPALIVE_CNT';
+option_name(tcp_keepalive_idle) -> ?'ZMQ_TCP_KEEPALIVE_IDLE';
+option_name(tcp_keepalive_intvl) -> ?'ZMQ_TCP_KEEPALIVE_INTVL';
+option_name(immediate) -> ?'ZMQ_IMMEDIATE';
+option_name(xpub_verbose) -> ?'ZMQ_XPUB_VERBOSE';
+option_name(router_raw) -> ?'ZMQ_ROUTER_RAW';
+option_name(ipv6) -> ?'ZMQ_IPV6';
+option_name(mechanism) -> ?'ZMQ_MECHANISM';
+option_name(plain_server) -> ?'ZMQ_PLAIN_SERVER';
+option_name(plain_username) -> ?'ZMQ_PLAIN_USERNAME';
+option_name(plain_password) -> ?'ZMQ_PLAIN_PASSWORD';
+option_name(curve_server) -> ?'ZMQ_CURVE_SERVER';
+option_name(curve_publickey) -> ?'ZMQ_CURVE_PUBLICKEY';
+option_name(curve_secretkey) -> ?'ZMQ_CURVE_SECRETKEY';
+option_name(curve_serverkey) -> ?'ZMQ_CURVE_SERVERKEY';
+option_name(probe_router) -> ?'ZMQ_PROBE_ROUTER';
+option_name(req_correlate) -> ?'ZMQ_REQ_CORRELATE';
+option_name(req_relaxed) -> ?'ZMQ_REQ_RELAXED';
+option_name(conflate) -> ?'ZMQ_CONFLATE';
+option_name(zap_domain) -> ?'ZMQ_ZAP_DOMAIN';
+option_name(router_handover) -> ?'ZMQ_ROUTER_HANDOVER';
+option_name(tos) -> ?'ZMQ_TOS';
+option_name(connect_routing_id) -> ?'ZMQ_CONNECT_ROUTING_ID';
+option_name(gssapi_server) -> ?'ZMQ_GSSAPI_SERVER';
+option_name(gssapi_principal) -> ?'ZMQ_GSSAPI_PRINCIPAL';
+option_name(gssapi_service_principal) -> ?'ZMQ_GSSAPI_SERVICE_PRINCIPAL';
+option_name(gssapi_plaintext) -> ?'ZMQ_GSSAPI_PLAINTEXT';
+option_name(handshake_ivl) -> ?'ZMQ_HANDSHAKE_IVL';
+option_name(socks_proxy) -> ?'ZMQ_SOCKS_PROXY';
+option_name(xpub_nodrop) -> ?'ZMQ_XPUB_NODROP';
+% context option
+% option_name(blocky) -> ?'ZMQ_BLOCKY';
+option_name(xpub_manual) -> ?'ZMQ_XPUB_MANUAL';
+option_name(xpub_welcome_msg) -> ?'ZMQ_XPUB_WELCOME_MSG';
+option_name(stream_notify) -> ?'ZMQ_STREAM_NOTIFY';
+option_name(invert_matching) -> ?'ZMQ_INVERT_MATCHING';
+option_name(heartbeat_ivl) -> ?'ZMQ_HEARTBEAT_IVL';
+option_name(heartbeat_ttl) -> ?'ZMQ_HEARTBEAT_TTL';
+option_name(heartbeat_timeout) -> ?'ZMQ_HEARTBEAT_TIMEOUT';
+option_name(xpub_verboser) -> ?'ZMQ_XPUB_VERBOSER';
+option_name(connect_timeout) -> ?'ZMQ_CONNECT_TIMEOUT';
+option_name(tcp_maxrt) -> ?'ZMQ_TCP_MAXRT';
+option_name(thread_safe) -> ?'ZMQ_THREAD_SAFE';
+option_name(multicast_maxtpdu) -> ?'ZMQ_MULTICAST_MAXTPDU';
+option_name(vmci_buffer_size) -> ?'ZMQ_VMCI_BUFFER_SIZE';
+option_name(vmci_buffer_min_size) -> ?'ZMQ_VMCI_BUFFER_MIN_SIZE';
+option_name(vmci_buffer_max_size) -> ?'ZMQ_VMCI_BUFFER_MAX_SIZE';
+option_name(vmci_connect_timeout) -> ?'ZMQ_VMCI_CONNECT_TIMEOUT';
+option_name(use_fd) -> ?'ZMQ_USE_FD';
+option_name(gssapi_principal_nametype) -> ?'ZMQ_GSSAPI_PRINCIPAL_NAMETYPE';
+option_name(gssapi_service_principal_nametype) -> ?'ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE';
+option_name(bindtodevice) -> ?'ZMQ_BINDTODEVICE';
+% deprecated
+option_name(ipv4only) -> ?'ZMQ_IPV4ONLY';
+option_name(tcp_accept_filter) -> ?'ZMQ_TCP_ACCEPT_FILTER';
+option_name(connect_rid) -> ?'ZMQ_CONNECT_RID';
+option_name(delay_attach_on_connect) -> ?'ZMQ_DELAY_ATTACH_ON_CONNECT';
+option_name(noblock) -> ?'ZMQ_NOBLOCK';
+option_name(fail_unroutable) -> ?'ZMQ_FAIL_UNROUTABLE';
+option_name(router_behavior) -> ?'ZMQ_ROUTER_BEHAVIOR';
+option_name(identity) -> ?'ZMQ_IDENTITY'.

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -297,7 +297,8 @@ timeo() ->
                            {ok, Sc} = erlzmq:socket(Ctx, [push, {active, false}]),
                            ok = erlzmq:connect(Sc, "inproc://timeout_test"),
                            timer:sleep(1000),
-                           ok = erlzmq:close(Sc)
+                           % can't match here as close may return eterm on terminated context
+                           erlzmq:close(Sc)
                    end),
     {Elapsed1, _} = timer:tc(fun() ->
                                      ?assertMatch({error, eagain}, erlzmq:recv(Sb))
@@ -352,8 +353,8 @@ shutdown_stress_loop(0) ->
 shutdown_stress_loop(N) ->
     {ok, C} = erlzmq:context(7),
     {ok, S1} = erlzmq:socket(C, [rep, {active, false}]),
-    ?assertMatch(ok, shutdown_stress_worker_loop(100, C)),
-    ?assertMatch(ok, join_procs(100)),
+    ?assertMatch(ok, shutdown_stress_worker_loop(20, C)),
+    ?assertMatch(ok, join_procs(20)),
     ?assertMatch(ok, erlzmq:close(S1)),
     ?assertMatch(ok, erlzmq:term(C)),
     shutdown_stress_loop(N-1).


### PR DESCRIPTION
This PR adds new socket options, socket type and error code introduced in ZMQ versions 4.0, 4.1, 4.2 and 4.3. As this library does not requre specific version the new options are behind `#if`