### PR TITLE
Socket timeout handling breaks message guarantees

### DIFF
--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -186,13 +186,6 @@ send({I, Socket}, Binary, Flags)
                     ok;
                 {Ref, {error, _} = Error} ->
                     Error
-            after case  erlzmq_nif:getsockopt(Socket,?'ZMQ_SNDTIMEO') of
-                       {ok, -1} ->
-                           infinity;
-                       {ok, Else} ->
-                           Else
-                   end ->
-                    {error, eagain}
             end;
         Result ->
             Result
@@ -251,13 +244,6 @@ recv({I, Socket}, Flags)
                     Error;
                 {Ref, Result} ->
                     {ok, Result}
-            after case erlzmq_nif:getsockopt(Socket,?'ZMQ_RCVTIMEO') of
-                      {ok, -1} ->
-                          infinity;
-                      {ok, Else} ->
-                          Else
-                  end ->
-                    {error, eagain}
             end;
         Result ->
             Result

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -492,3 +492,49 @@ basic_tests(Transport, Type1, Type2, Mode) ->
     ok = erlzmq:close(S2),
     ok = erlzmq:term(C).
 
+recv_timeout_breaks_message_guarantees_test() ->
+    ?PRINT_START,
+    {ok, C} = erlzmq:context(1),
+    {ok, S1} = erlzmq:socket(C, [push, {active, false}]),
+    {ok, S2} = erlzmq:socket(C, [pull, {active, false}]),
+
+    ok = erlzmq:setsockopt(S2, sndtimeo, 500),
+    ok = erlzmq:setsockopt(S2, rcvtimeo, 500),
+
+    ok = erlzmq:connect(S1, "tcp://127.0.0.1:5559"),
+    ok = erlzmq:bind(S2, "tcp://*:5559"),
+
+    ok = erlzmq:send(S1, <<"ABC">>, [sndmore]),
+    ok = erlzmq:send(S1, <<"DEF">>),
+
+    %% send and receive a multipart message. should be fine.
+    {ok, Msg1} = erlzmq:recv(S2),
+    ?assertMatch(<<"ABC">> , Msg1),
+    {ok, RcvMore1} = erlzmq:getsockopt(S2, rcvmore),
+    ?assert(RcvMore1 > 0),
+    {ok, Msg2} = erlzmq:recv(S2),
+    {ok, RcvMore2} = erlzmq:getsockopt(S2, rcvmore),
+    ?assertMatch(0, RcvMore2),
+    ?assertMatch(<<"DEF">>, Msg2),
+
+    %% try to read when no message is there. this should time out.
+    ?assertMatch({error, eagain}, erlzmq:recv(S2)),
+
+    %% send the next multipart message.
+    ok = erlzmq:send(S1, <<"GHI">>, [sndmore]),
+    ok = erlzmq:send(S1, <<"JKL">>),
+
+    %% this will drop the first part of the message just sent.
+    {ok, Msg3} = erlzmq:recv(S2),
+    ?assertMatch(<<"GHI">> , Msg3),
+    {ok, RcvMore3} = erlzmq:getsockopt(S2, rcvmore),
+    ?assert(RcvMore3 > 0),
+    {ok, Msg4} = erlzmq:recv(S2),
+    {ok, RcvMore4} = erlzmq:getsockopt(S2, rcvmore),
+    ?assertMatch(0, RcvMore4),
+    ?assertMatch(<<"JKL">>, Msg4),
+
+    ok = erlzmq:close(S1),
+    ok = erlzmq:close(S2),
+    ok = erlzmq:term(C),
+    ?PRINT_END.

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -509,30 +509,31 @@ recv_timeout_breaks_message_guarantees_test() ->
 
     %% send and receive a multipart message. should be fine.
     {ok, Msg1} = erlzmq:recv(S2),
-    ?assertMatch(<<"ABC">> , Msg1),
+    ?assertEqual(<<"ABC">> , Msg1),
     {ok, RcvMore1} = erlzmq:getsockopt(S2, rcvmore),
     ?assert(RcvMore1 > 0),
     {ok, Msg2} = erlzmq:recv(S2),
     {ok, RcvMore2} = erlzmq:getsockopt(S2, rcvmore),
-    ?assertMatch(0, RcvMore2),
-    ?assertMatch(<<"DEF">>, Msg2),
+    ?assertEqual(0, RcvMore2),
+    ?assertEqual(<<"DEF">>, Msg2),
 
     %% try to read when no message is there. this should time out.
+
     ?assertMatch({error, eagain}, erlzmq:recv(S2)),
 
-    %% send the next multipart message.
+    %% %% send the next multipart message.
     ok = erlzmq:send(S1, <<"GHI">>, [sndmore]),
     ok = erlzmq:send(S1, <<"JKL">>),
 
-    %% this will drop the first part of the message just sent.
+    %% now receive all parts.
     {ok, Msg3} = erlzmq:recv(S2),
-    ?assertMatch(<<"GHI">> , Msg3),
+    ?assertEqual(<<"GHI">> , Msg3),
     {ok, RcvMore3} = erlzmq:getsockopt(S2, rcvmore),
     ?assert(RcvMore3 > 0),
     {ok, Msg4} = erlzmq:recv(S2),
     {ok, RcvMore4} = erlzmq:getsockopt(S2, rcvmore),
-    ?assertMatch(0, RcvMore4),
-    ?assertMatch(<<"JKL">>, Msg4),
+    ?assertEqual(0, RcvMore4),
+    ?assertEqual(<<"JKL">>, Msg4),
 
     ok = erlzmq:close(S1),
     ok = erlzmq:close(S2),


### PR DESCRIPTION
The handling of send/receive timeouts is buggy in the current implementation. Messages will be lost when they arrive after a socket timeout.

This patch fixes the problem by moving the timeout handling from the erlang code to the poller thread.